### PR TITLE
Allow empty version

### DIFF
--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -30,6 +30,8 @@ abstract class DependencyReference extends Jsonable {
       }
     } else if (json is String) {
       return new HostedReference.fromJson(json);
+    } else if (json == null) {
+      return new HostedReference(VersionConstraint.any);
     } else {
       throw new StateError('Unable to parse dependency $json');
     }
@@ -43,6 +45,7 @@ class GitReference extends DependencyReference {
   final String ref;
 
   GitReference(this.url, this.ref);
+
   factory GitReference.fromJson(Map json) {
     final git = json['git'];
     if (git is String) {
@@ -129,8 +132,7 @@ class SdkReference extends DependencyReference {
 
   SdkReference.fromJson(Map json) : this(json['sdk']);
 
-  bool operator ==(other) =>
-      other is SdkReference && other.sdk == sdk;
+  bool operator ==(other) => other is SdkReference && other.sdk == sdk;
 
   @override
   toJson() {

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -25,6 +25,24 @@ main() {
     expect(exDep.versionConstraint.toString(), '^0.1.0');
   });
 
+  /// According to https://www.dartlang.org/tools/pub/dependencies#version-constraints:
+  ///
+  /// The string any allows any version. This is equivalent to an empty
+  /// version constraint, but is more explicit.
+  test('dependency without the version constraint is "any" version', () {
+    var pubspecString = 'name: my_test_lib\n'
+        'version: 0.1.0\n'
+        'description: for testing\n'
+        'dependencies:\n'
+        '    meta:\n';
+    var p = new PubSpec.fromYamlString(pubspecString);
+    var dep = p.dependencies['meta'];
+    expect(dep, TypeMatcher<HostedReference>());
+
+    var exDep = dep as HostedReference;
+    expect(exDep.versionConstraint.toString(), 'any');
+  });
+
   test('sdk dependency', () {
     var pubspecString = 'name: my_test_lib\n'
         'version: 0.1.0\n'


### PR DESCRIPTION
The [documentation allows](https://www.dartlang.org/tools/pub/dependencies#version-constraints) empty version constraints, but the library fails with 
```
Unhandled exception:
Bad state: Unable to parse dependency null
```
when parsing a `pubspec.yaml` containing dependencies with empty version constraints.

This PR treats such dependencies as having "any" version allowed.