### PR TITLE
Fixed the ubiquitous use of quotes & small syntax refactoring

### DIFF
--- a/lib/pubspec.dart
+++ b/lib/pubspec.dart
@@ -8,3 +8,4 @@ library pubspec;
 
 export 'src/dependency.dart';
 export 'src/pubspec.dart';
+export 'src/yaml_to_string.dart';

--- a/lib/src/yaml_to_string.dart
+++ b/lib/src/yaml_to_string.dart
@@ -1,0 +1,115 @@
+final _unsuportedCharacters = RegExp(
+    r'''^[\n\t ,[\]{}#&*!|<>'"%@']|^[?-]$|^[?-][ \t]|[\n:][ \t]|[ \t]\n|[\n\t ]#|[\n\t :]$''');
+
+class YamlToString {
+  const YamlToString({
+    this.indent = ' ',
+    this.quotes = "'",
+  });
+
+  final String indent, quotes;
+  static final _divider = ': ';
+
+  String toYamlString(node) {
+    final stringBuffer = StringBuffer();
+    writeYamlString(node, stringBuffer);
+    return stringBuffer.toString();
+  }
+
+  /// Serializes [node] into a String and writes it to the [sink].
+  void writeYamlString(node, StringSink sink) {
+    _writeYamlString(node, 0, sink, true);
+  }
+
+  void _writeYamlString(
+    node,
+    int indentCount,
+    StringSink stringSink,
+    bool isTopLevel,
+  ) {
+    if (node is Map) {
+      _mapToYamlString(node, indentCount, stringSink, isTopLevel);
+    } else if (node is Iterable) {
+      _listToYamlString(node, indentCount, stringSink, isTopLevel);
+    } else if (node is String) {
+      stringSink.writeln(_escapeString(node));
+    } else if (node is double) {
+      stringSink.writeln("!!float $node");
+    } else {
+      stringSink.writeln(node);
+    }
+  }
+
+  String _escapeString(String line) {
+    line = line.replaceAll('"', r'\"').replaceAll('\n', r'\n');
+
+    if (line.contains(_unsuportedCharacters)) {
+      line = quotes + line + quotes;
+    }
+
+    return line;
+  }
+
+  void _mapToYamlString(
+    node,
+    int indentCount,
+    StringSink stringSink,
+    bool isTopLevel,
+  ) {
+    if (!isTopLevel) {
+      stringSink.writeln();
+      indentCount += 2;
+    }
+
+    final keys = _sortKeys(node);
+
+    keys.forEach((key) {
+      final value = node[key];
+      _writeIndent(indentCount, stringSink);
+      stringSink..write(key)..write(_divider);
+      _writeYamlString(value, indentCount, stringSink, false);
+    });
+  }
+
+  Iterable<String> _sortKeys(Map map) {
+    final simple = <String>[],
+        maps = <String>[],
+        lists = <String>[],
+        other = <String>[];
+
+    map.forEach((key, value) {
+      if (value is String) {
+        simple.add(key);
+      } else if (value is Map) {
+        maps.add(key);
+      } else if (value is Iterable) {
+        lists.add(key);
+      } else {
+        other.add(key);
+      }
+    });
+
+    return [...simple, ...maps, ...lists, ...other];
+  }
+
+  void _listToYamlString(
+    Iterable node,
+    int indentCount,
+    StringSink stringSink,
+    bool isTopLevel,
+  ) {
+    if (!isTopLevel) {
+      stringSink.writeln();
+      indentCount += 2;
+    }
+
+    node.forEach((value) {
+      _writeIndent(indentCount, stringSink);
+      stringSink.write('- ');
+      _writeYamlString(value, indentCount, stringSink, false);
+    });
+  }
+
+  void _writeIndent(int indentCount, StringSink stringSink) =>
+      stringSink.write(indent * indentCount);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,14 @@
-author: "Anders Holmgren <andersmholmgren@gmail.com>"
-description: "A library for manipulating [pubspec](https://www.dartlang.org/tools/pub/pubspec.html) files"
-homepage: "https://github.com/Andersmholmgren/pubspec"
-name: "pubspec"
-version: "0.1.1"
+author: Anders Holmgren <andersmholmgren@gmail.com>
+description: A library for manipulating [pubspec](https://www.dartlang.org/tools/pub/pubspec.html) files
+homepage: https://github.com/Andersmholmgren/pubspec
+name: pubspec
+version: 0.1.2
 dependencies: 
-  path: "^1.6.2"
-  pub_semver: "^1.4.2"
-  stuff: "^0.1.0"
-  yaml: "^2.1.15"
-  yamlicious: "^0.1.0"
+  path: ^1.6.2
+  pub_semver: ^1.4.2
+  stuff: ^0.1.0
+  yaml: ^2.1.15
 dev_dependencies: 
-  test: "^1.3.3"
+  test: ^1.3.3
 environment: 
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.2.2 <3.0.0'


### PR DESCRIPTION
__save pubspec result before:__
```yaml
author: "Serge Shkurko <SergeShkurko@outlook.com>"
description: "Run commands upon installing Dart packages, and more."
homepage: "https://github.com/rbcprolabs/dpm"
name: "dpm"
version: "0.0.1"
dependencies: 
  args: "^1.5.2"
  collection: "1.14.11"
  console: "^3.1.0"
  http: "^0.12.0+2"
  path: "^1.6.2"
  pub_semver: "1.4.2"
  pubspec: "^0.1.1"
  quiver: "2.0.3"
  tuple: "^1.0.2"
  yaml: "^2.1.16"
  yamlicious: "^0.1.0"
dev_dependencies: 
  network: "0.6.0"
  pedantic: "1.8.0+1"
  test: "^1.6.5"
environment: 
  sdk: ">=2.3.0-dev.0.5 <3.0.0"
executables: 
  dpm: "dpm"
```
**save pubspec result after:**
```yaml
name: dpm
author: Serge Shkurko <SergeShkurko@outlook.com>
version: 0.0.1
homepage: https://github.com/rbcprolabs/dpm
description: Run commands upon installing Dart packages, and more.
environment: 
  sdk: '>=2.3.0-dev.0.5 <3.0.0'
dependencies: 
  quiver: ^2.0.3
  args: ^1.5.2
  collection: ^1.14.11
  yamlicious: ^0.1.0
  http: ^0.12.0+2
  pub_semver: ^1.4.2
  console: ^3.1.0
  path: ^1.6.2
  pubspec: ^0.1.1
  register: ^1.0.0
  yaml: ^2.1.16
  colorize: ^2.0.0
  tuple: ^1.0.2
dev_dependencies: 
  test: ^1.6.5
  pedantic: ^1.8.0+1
dependency_overrides: 
  pubspec: 
    path: ../pubspec
executables: 
  dpm: dpm
```