### PR TITLE
removed the dependency on package stuff as it had a dependency on mirrors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.1.3
+Demoved the dependency on the stuff package has it had a dependency on mirrors. The result is that you couldn't do a native compile of any package dependent on pubspec. Copied the class Json_utils.dart from stuff package to make this possible.
 
 ## 0.1.1
 

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -6,7 +6,8 @@ library pubspec.dependency;
 import 'dart:convert';
 
 import 'package:pub_semver/pub_semver.dart';
-import 'package:stuff/stuff.dart';
+
+import 'json_utils.dart';
 
 abstract class DependencyReference extends Jsonable {
   DependencyReference();

--- a/lib/src/json_utils.dart
+++ b/lib/src/json_utils.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2015, Anders Holmgren. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+library stuff.json;
+
+import 'package:uri/uri.dart';
+
+abstract class Jsonable {
+  toJson();
+}
+
+JsonBuilder get buildJson => new JsonBuilder();
+JsonParser parseJson(Map j, {bool consumeMap: false}) =>
+    new JsonParser(j, consumeMap);
+
+class JsonBuilder {
+  final bool _stringEmpties;
+  JsonBuilder({bool stringEmpties: true}) : this._stringEmpties = stringEmpties;
+
+  final Map json = {};
+
+//  void addObject(String fieldName, o) {
+//    if (o != null) {
+//      json[fieldName] = o.toJson();
+//    }
+//  }
+
+  void add(String fieldName, v, [transform(v)]) {
+    if (v != null) {
+      final transformed = _transformValue(v, transform);
+      if (transformed != null) {
+        json[fieldName] = transformed;
+      }
+    }
+  }
+
+  void addAll(Map map) {
+    json.addAll(map);
+  }
+
+  _transformValue(value, [transform(v)]) {
+    if (transform != null) {
+      return transform(value);
+    }
+    if (value is Jsonable) {
+      return value.toJson();
+    }
+    if (value is Map) {
+      final result = {};
+      value.forEach((k, v) {
+        final transformedValue = _transformValue(v);
+        final transformedKey = _transformValue(k);
+        if (transformedValue != null && transformedKey != null) {
+          result[transformedKey] = transformedValue;
+        }
+      });
+      return result.isNotEmpty || !_stringEmpties ? result : null;
+    }
+    if (value is Iterable) {
+      final list = value.map((v) => _transformValue(v, null)).toList();
+      return list.isNotEmpty || !_stringEmpties ? list : null;
+    }
+    if (value is RegExp) {
+      return value.pattern;
+    }
+    if (value is UriTemplate) {
+      return value.template;
+    }
+    if (value is DateTime) {
+      return value.toIso8601String();
+    }
+    if (value is bool || value is num) {
+      return value;
+    }
+    return value.toString();
+  }
+}
+
+typedef T Converter<T>(value);
+
+Converter<T> _converter<T>(Converter<T> convert) =>
+    convert ?? (v) => v as T;
+
+class JsonParser {
+  final Map _json;
+  final bool _consumeMap;
+
+  JsonParser(Map json, bool consumeMap)
+      : this._json = consumeMap ? new Map.from(json) : json,
+        this._consumeMap = consumeMap;
+
+  List<T> list<T>(String fieldName, [Converter<T> create]) {
+    final List l = _getField(fieldName);
+    return l != null ? l.map(_converter(create)).toList(growable: false) : [];
+  }
+
+  T single<T>(String fieldName, [T create(i)]) {
+    final j = _getField(fieldName);
+    return j != null ? _converter(create)(j) : null;
+  }
+
+  Map<K, V> mapValues<K, V>(String fieldName,
+      [Converter<V> convertValue, Converter<K> convertKey]) {
+    final Map m = _getField(fieldName);
+
+    if (m == null) {
+      return {};
+    }
+
+    Converter<K> _convertKey = _converter(convertKey);
+    Converter<V> _convertValue = _converter(convertValue);
+
+    Map<K, V> result = new Map<K, V>();
+    m.forEach((k, v) {
+      result[_convertKey(k)] = _convertValue(v);
+    });
+
+    return result;
+  }
+
+  T _getField<T>(String fieldName) =>
+      (_consumeMap ? _json.remove(fieldName) : _json[fieldName]);
+
+  Map get unconsumed {
+    if (!_consumeMap) {
+      throw new StateError('unconsumed called on non consuming parser');
+    }
+
+    return _json;
+  }
+}

--- a/lib/src/json_utils.dart
+++ b/lib/src/json_utils.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2015, Anders Holmgren. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
-library stuff.json;
-
 import 'package:uri/uri.dart';
 
 abstract class Jsonable {
@@ -78,8 +76,7 @@ class JsonBuilder {
 
 typedef T Converter<T>(value);
 
-Converter<T> _converter<T>(Converter<T> convert) =>
-    convert ?? (v) => v as T;
+Converter<T> _converter<T>(Converter<T> convert) => convert ?? (v) => v as T;
 
 class JsonParser {
   final Map _json;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -10,8 +10,9 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec/src/dependency.dart';
 import 'package:pubspec/src/yaml_to_string.dart';
-import 'package:stuff/stuff.dart';
 import 'package:yaml/yaml.dart';
+
+import 'json_utils.dart';
 
 /// Represents a [pubspec](https://www.dartlang.org/tools/pub/pubspec.html).
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,12 +2,12 @@ author: Anders Holmgren <andersmholmgren@gmail.com>
 description: A library for manipulating [pubspec](https://www.dartlang.org/tools/pub/pubspec.html) files
 homepage: https://github.com/Andersmholmgren/pubspec
 name: pubspec
-version: 0.1.2
+version: 0.1.3
 dependencies: 
   path: ^1.6.2
   pub_semver: ^1.4.2
-  stuff: ^0.1.0
   yaml: ^2.1.15
+  uri: "^0.11.3+1"
 dev_dependencies: 
   test: ^1.3.3
 environment: 


### PR DESCRIPTION
The result is that you couldn't do a native compile of any package dependent on pubspec. Copied the class Json_utils.dart from stuff package to make this possible.

Fixes:  #12